### PR TITLE
Explicit button color change on metamask connect

### DIFF
--- a/components/MetamaskButton.vue
+++ b/components/MetamaskButton.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-btn
-      color="primary"
+      :color="showPayButton ? 'success' : 'primary'"
       :disabled="insufficientBalance"
       :loading="loading"
       @click="connectToMetamask"


### PR DESCRIPTION
It is easy to miss the changed title of metamask button now (from "Connect to Metamask" to "Pay with Metamask") so this might be perceived as a bug due to poor UX ("non responsive button") when customer needs to click the same button twice.

Attaching quick(est) fix for this - now the button color is changed on first click.

![image](https://user-images.githubusercontent.com/775507/168275206-339646b0-2d2f-4a2c-bbf6-fdfe2a3dd483.png)
